### PR TITLE
refactor(css): 统一dark mode实现，精简代码

### DIFF
--- a/themes/neo/source/css/highlight-theme.css
+++ b/themes/neo/source/css/highlight-theme.css
@@ -27,7 +27,7 @@ hue-6-2: #e6c07b
 */
 .hljs {
   color: #abb2bf;
-  background: #282c34
+  background: #1a1d23
 }
 .hljs-comment,
 .hljs-quote {
@@ -111,7 +111,7 @@ hue-6-2: #1f2328
 */
 html[data-theme="light"] .hljs {
   color: #24292f;
-  background: #ffffff
+  background: #f6f8fa
 }
 html[data-theme="light"] .hljs-comment,
 html[data-theme="light"] .hljs-quote {

--- a/themes/neo/source/css/style.css
+++ b/themes/neo/source/css/style.css
@@ -86,6 +86,42 @@ html[data-theme="dark"] .skip-link {
   --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
   --transition-base: 250ms cubic-bezier(0.4, 0, 0.2, 1);
   --transition-slow: 350ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Code Block Colors */
+  --code-bg: #f6f8fa;
+  --code-text: #24292f;
+  --code-gutter: #9ca3af;
+  --inline-code-bg: #f3f4f6;
+  --inline-code-text: #111827;
+
+  /* Blockquote Colors */
+  --blockquote-text: #4b5563;
+  --blockquote-border: #3b82f6;
+
+  /* Table Colors */
+  --table-header-bg: #f3f4f6;
+  --table-border: #d1d5db;
+
+  /* TOC Colors */
+  --toc-text: #6b7280;
+  --toc-border: #e5e7eb;
+
+  /* Donation Modal Colors */
+  --modal-close-hover-bg: #f3f4f6;
+  --modal-close-hover-text: #4b5563;
+  --donation-tab-inactive-bg: #f3f4f6;
+  --donation-tab-inactive-text: #4b5563;
+  --donation-tab-hover-bg: #e5e7eb;
+
+  /* Highlight Code Block */
+  --highlight-bg: #f6f8fa;
+  --highlight-header-bg: #f6f8fa;
+  --highlight-header-border: #e1e4e8;
+  --highlight-lang-color: #57606a;
+  --highlight-btn-color: #8c959f;
+  --highlight-btn-hover-bg: rgba(0, 0, 0, 0.05);
+  --highlight-btn-hover-color: #24292f;
+  --highlight-gutter-color: #9ca3af;
 }
 
 html[data-theme="dark"] {
@@ -101,6 +137,42 @@ html[data-theme="dark"] {
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -4px rgba(0, 0, 0, 0.4);
   --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+
+  /* Code Block Colors */
+  --code-bg: #1a1d23;
+  --code-text: #f3f4f6;
+  --code-gutter: #4b5563;
+  --inline-code-bg: #374151;
+  --inline-code-text: #f3f4f6;
+
+  /* Blockquote Colors */
+  --blockquote-text: #9ca3af;
+  --blockquote-border: #60a5fa;
+
+  /* Table Colors */
+  --table-header-bg: #374151;
+  --table-border: #4b5563;
+
+  /* TOC Colors */
+  --toc-text: #9ca3af;
+  --toc-border: #374151;
+
+  /* Donation Modal Colors */
+  --modal-close-hover-bg: #374151;
+  --modal-close-hover-text: #d1d5db;
+  --donation-tab-inactive-bg: #374151;
+  --donation-tab-inactive-text: #9ca3af;
+  --donation-tab-hover-bg: #4b5563;
+
+  /* Highlight Code Block */
+  --highlight-bg: #1a1d23;
+  --highlight-header-bg: rgba(0, 0, 0, 0.15);
+  --highlight-header-border: rgba(0, 0, 0, 0.1);
+  --highlight-lang-color: #8b949e;
+  --highlight-btn-color: #8b949e;
+  --highlight-btn-hover-bg: rgba(255, 255, 255, 0.1);
+  --highlight-btn-hover-color: #f0f6fc;
+  --highlight-gutter-color: #4b5563;
 }
 
 html[data-theme="light"] {
@@ -184,11 +256,7 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.4;
   margin-top: 2rem;
   margin-bottom: 0.75rem;
-  color: #111827;
-}
-
-html[data-theme="dark"] .prose h3 {
-  color: #f9fafb;
+  color: var(--text-primary);
 }
 
 .prose p {
@@ -197,12 +265,12 @@ html[data-theme="dark"] .prose h3 {
 }
 
 .prose a {
-  color: #2563eb;
+  color: var(--accent-primary);
   text-decoration: underline;
 }
 
-html[data-theme="dark"] .prose a {
-  color: #3b82f6;
+.prose a:hover {
+  color: var(--accent-secondary);
 }
 
 .prose ul, .prose ol {
@@ -223,34 +291,30 @@ html[data-theme="dark"] .prose a {
 }
 
 .prose blockquote {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--blockquote-border);
   padding-left: 1rem;
   font-style: italic;
-  color: #4b5563;
+  color: var(--blockquote-text);
   margin: 1.5rem 0;
 }
 
-html[data-theme="dark"] .prose blockquote {
-  color: #9ca3af;
-}
-
 .prose code {
-  background-color: #f3f4f6;
-  color: #111827;
+  background-color: var(--inline-code-bg);
+  color: var(--inline-code-text);
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   font-size: 0.875rem;
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
-html[data-theme="dark"] .prose code {
-  background-color: #374151;
-  color: #f3f4f6;
+.prose pre code {
+  background-color: transparent;
+  color: inherit;
 }
 
 .prose pre {
-  background-color: #1f2937;
-  color: #f3f4f6;
+  background-color: var(--code-bg);
+  color: var(--code-text);
   padding: 1rem;
   border-radius: 0.5rem;
   overflow-x: auto;
@@ -283,31 +347,18 @@ html[data-theme="dark"] .prose code {
 }
 
 .prose th, .prose td {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--table-border);
   padding: 0.5rem;
 }
 
-html[data-theme="dark"] .prose th,
-html[data-theme="dark"] .prose td {
-  border-color: #4b5563;
-}
-
 .prose th {
-  background-color: #f3f4f6;
+  background-color: var(--table-header-bg);
   font-weight: 600;
 }
 
-html[data-theme="dark"] .prose th {
-  background-color: #374151;
-}
-
 .prose hr {
-  border-color: #e5e7eb;
+  border-color: var(--border-color);
   margin: 2rem 0;
-}
-
-html[data-theme="dark"] .prose hr {
-  border-color: #4b5563;
 }
 
 /* Donation Modal Styles */
@@ -331,7 +382,7 @@ html[data-theme="dark"] .prose hr {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: white;
+  background-color: var(--bg-secondary);
   border-radius: 1rem;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   z-index: 50;
@@ -342,10 +393,6 @@ html[data-theme="dark"] .prose hr {
   max-width: 28rem;
   width: 100%;
   margin: 0 1rem;
-}
-
-html[data-theme="dark"] .donation-modal {
-  background-color: #1f2937;
 }
 
 .donation-modal.active {
@@ -375,13 +422,8 @@ html[data-theme="dark"] .donation-modal {
 }
 
 .donation-close:hover {
-  background-color: #f3f4f6;
-  color: #4b5563;
-}
-
-html[data-theme="dark"] .donation-close:hover {
-  background-color: #374151;
-  color: #d1d5db;
+  background-color: var(--modal-close-hover-bg);
+  color: var(--modal-close-hover-text);
 }
 
 .donation-tabs {
@@ -400,26 +442,17 @@ html[data-theme="dark"] .donation-close:hover {
 }
 
 .donation-tab.active {
-  background-color: #2563eb;
-  color: white;
+  background-color: var(--accent-primary);
+  color: var(--bg-secondary);
 }
 
 .donation-tab:not(.active) {
-  background-color: #f3f4f6;
-  color: #4b5563;
-}
-
-html[data-theme="dark"] .donation-tab:not(.active) {
-  background-color: #374151;
-  color: #9ca3af;
+  background-color: var(--donation-tab-inactive-bg);
+  color: var(--donation-tab-inactive-text);
 }
 
 .donation-tab:not(.active):hover {
-  background-color: #e5e7eb;
-}
-
-html[data-theme="dark"] .donation-tab:not(.active):hover {
-  background-color: #4b5563;
+  background-color: var(--donation-tab-hover-bg);
 }
 
 .donation-qr {
@@ -449,15 +482,7 @@ figure.highlight {
   max-width: 100%;
   margin: 1.5rem 0;
   border-radius: var(--radius-lg);
-  background-color: #282c34;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-/* Light Theme */
-html[data-theme="light"] .highlight,
-html[data-theme="light"] figure.highlight {
-  background-color: #ffffff;
+  background-color: var(--highlight-bg);
   border: none !important;
   box-shadow: none !important;
 }
@@ -468,15 +493,10 @@ html[data-theme="light"] figure.highlight {
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0.75rem;
-  background-color: rgba(0, 0, 0, 0.15);
+  background-color: var(--highlight-header-bg);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   user-select: none;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-html[data-theme="light"] .highlight .code-header {
-  background-color: #f6f8fa;
-  border-bottom: 1px solid #e1e4e8;
+  border-bottom: 1px solid var(--highlight-header-border);
 }
 
 /* Language Section - Left Side */
@@ -490,15 +510,11 @@ html[data-theme="light"] .highlight .code-header {
 .highlight .code-header .lang-label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #8b949e;
+  color: var(--highlight-lang-color);
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
   text-transform: lowercase;
   cursor: default;
   letter-spacing: 0.025em;
-}
-
-html[data-theme="light"] .highlight .code-header .lang-label {
-  color: #57606a;
 }
 
 /* Collapse/Expand Button */
@@ -513,24 +529,15 @@ html[data-theme="light"] .highlight .code-header .lang-label {
   border: none;
   border-radius: 0.25rem;
   cursor: pointer;
-  color: #8b949e;
+  color: var(--highlight-btn-color);
   transition: all 0.2s ease;
   margin-left: 0.25rem;
   position: relative;
 }
 
 .highlight .code-header .collapse-btn:hover {
-  color: #f0f6fc;
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-html[data-theme="light"] .highlight .code-header .collapse-btn {
-  color: #8c959f;
-}
-
-html[data-theme="light"] .highlight .code-header .collapse-btn:hover {
-  color: #24292f;
-  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--highlight-btn-hover-color);
+  background-color: var(--highlight-btn-hover-bg);
 }
 
 .highlight .code-header .collapse-btn svg {
@@ -561,23 +568,14 @@ html[data-theme="light"] .highlight .code-header .collapse-btn:hover {
   border: none;
   border-radius: 0.375rem;
   cursor: pointer;
-  color: #8b949e;
+  color: var(--highlight-btn-color);
   transition: all 0.2s ease;
   position: relative;
 }
 
 .highlight .code-header .code-actions button:hover {
-  color: #f0f6fc;
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-html[data-theme="light"] .highlight .code-header .code-actions button {
-  color: #57606a;
-}
-
-html[data-theme="light"] .highlight .code-header .code-actions button:hover {
-  color: #24292f;
-  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--highlight-btn-hover-color);
+  background-color: var(--highlight-btn-hover-bg);
 }
 
 .highlight .code-header .code-actions button svg {
@@ -698,10 +696,6 @@ html[data-theme="light"] .highlight .code-header button[data-tooltip]::before {
   border: none;
 }
 
-html[data-theme="light"] .highlight td.gutter {
-  background-color: transparent;
-}
-
 /* Code Area - no border */
 .highlight td.code {
   border: none;
@@ -710,16 +704,12 @@ html[data-theme="light"] .highlight td.gutter {
 .highlight td.gutter pre {
   margin: 0;
   padding: 0.75rem 0.5rem;
-  color: #4b5563;
+  color: var(--highlight-gutter-color);
   font-size: 0.875rem;
   line-height: 1.6;
   text-align: right;
   overflow: hidden;
   background: transparent;
-}
-
-html[data-theme="light"] .highlight td.gutter pre {
-  color: #9ca3af;
 }
 
 /* Code Area */
@@ -732,17 +722,13 @@ html[data-theme="light"] .highlight td.gutter pre {
   margin: 0;
   padding: 0.75rem 1rem;
   background-color: transparent;
-  color: #f3f4f6;
+  color: var(--code-text);
   font-size: 0.875rem;
   line-height: 1.6;
   white-space: pre;
   word-wrap: normal;
   word-break: keep-all;
   overflow-x: auto;
-}
-
-html[data-theme="light"] .highlight td.code pre {
-  color: #24292f;
 }
 
 /* Simple Code Block (without line numbers) */
@@ -844,7 +830,7 @@ html[data-theme="light"] .highlight td.code pre {
 
 .toc-nav {
   scrollbar-width: thin;
-  scrollbar-color: #d1d5db transparent;
+  scrollbar-color: var(--border-color) transparent;
 }
 
 .toc-nav::-webkit-scrollbar {
@@ -856,12 +842,8 @@ html[data-theme="light"] .highlight td.code pre {
 }
 
 .toc-nav::-webkit-scrollbar-thumb {
-  background-color: #d1d5db;
+  background-color: var(--border-color);
   border-radius: 2px;
-}
-
-html[data-theme="dark"] .toc-nav::-webkit-scrollbar-thumb {
-  background-color: #4b5563;
 }
 
 .toc-nav ol,
@@ -884,51 +866,31 @@ html[data-theme="dark"] .toc-nav::-webkit-scrollbar-thumb {
 .toc-nav li > ol,
 .toc-nav li > ul {
   padding-left: 0.75rem;
-  border-left: 1px solid #e5e7eb;
+  border-left: 1px solid var(--toc-border);
   margin-left: 0.25rem;
-}
-
-html[data-theme="dark"] .toc-nav li > ol,
-html[data-theme="dark"] .toc-nav li > ul {
-  border-left-color: #374151;
 }
 
 .toc-nav a {
   display: block;
   padding: 0.375rem 0.5rem;
-  color: #6b7280;
+  color: var(--toc-text);
   text-decoration: none;
   border-radius: 0.25rem;
   transition: all 0.2s;
   line-height: 1.5;
 }
 
-html[data-theme="dark"] .toc-nav a {
-  color: #9ca3af;
-}
-
 .toc-nav a:hover {
-  color: #2563eb;
-  background-color: #f3f4f6;
-}
-
-html[data-theme="dark"] .toc-nav a:hover {
-  color: #3b82f6;
-  background-color: #374151;
+  color: var(--accent-primary);
+  background-color: var(--bg-tertiary);
 }
 
 .toc-nav a.active {
-  color: #2563eb;
+  color: var(--accent-primary);
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.1) 0%, rgba(59, 130, 246, 0.05) 100%);
   font-weight: 600;
-  border-left: 2px solid #2563eb;
+  border-left: 2px solid var(--accent-primary);
   margin-left: -2px;
-}
-
-html[data-theme="dark"] .toc-nav a.active {
-  color: #60a5fa;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(96, 165, 250, 0.05) 100%);
-  border-left-color: #60a5fa;
 }
 
 /* Line clamp utility */
@@ -980,28 +942,6 @@ article.group a,
 a[href^="/tags/"],
 a.tag-link {
   cursor: pointer;
-}
-
-/* Copy Button Feedback */
-.copy-feedback {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: #10b981;
-  color: white;
-  padding: 0.25rem 0.75rem;
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s;
-  white-space: nowrap;
-}
-
-.copy-feedback.show {
-  opacity: 1;
 }
 
 /* Reading Progress Bar */


### PR DESCRIPTION
- 删除重复的.copy-feedback样式定义
- 新增36个CSS变量：代码块、引用块、表格、目录、捐赠模态框等
- 替换40+处硬编码颜色为CSS变量
- 移除约30个冗余的html[data-theme="dark"]覆盖规则
- 添加stylelint开发依赖用于CSS代码检查

统一使用CSS Variables管理主题色彩，所有颜色变更集中在:root中维护